### PR TITLE
Fixed RemarkAnchor props expecting children Array. Seems its just string

### DIFF
--- a/src/remark-anchor.js
+++ b/src/remark-anchor.js
@@ -3,8 +3,7 @@ import { useFetchData } from "./useFetchData";
 
 export function createRemarkAnchor(OrigA) {
   return function RemarkAnchor(props) {
-    const { href, children } = props;
-    const [label] = children instanceof Array ? children : [];
+    const { href, children: label } = props;
 
     const isAutoLinkEnabled = inkdrop.config.get("link-card.autolinks");
     const imageShape = inkdrop.config.get("link-card.imageShape");


### PR DESCRIPTION
Hey @elpnt 
It seems that the `RemarkAnchor`'s `children` is no longer an Array, but a string. 

Fixing that got the plugin working locally. (im on inkdrop v5.8.1)

Would you mind merging this in? 

thanks :) 